### PR TITLE
Avoid memory issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # ckanext-datapreview
 
+This CKAN extension supplies data from local storage or via a remote download, parses CSV/XLS and provides it at a URL that can be called by Recline or other CKAN data previewer.
+
+e.g. for a spreadsheet it returns a JSON dict such as:
+
+        {
+            "fields": ['Name', 'Age'],
+            "data": [['Bob', 42], ['Jill', 54]],
+            "extra_text": "This preview shows only the first 10 rows",
+            "max_results": 10,
+            "length": 435,
+            "url": "http://data.com/file.csv",
+        }
+
+(see helpers.proxy_query() )
+
 This extension is a modified, but local implementation of the [OKFN dataproxy](https://github.com/okfn/dataproxy) that runs as a CKAN extension rather than on [Google AppEngine](http://jsonpdataproxy.appspot.com). This has been written to improve the performance on [data.gov.uk](data.gov.uk) and increase the maximum file size processed.
 
 The interface to the extension::
@@ -22,6 +37,19 @@ Or alternatively install directly using pip:
 
 Once complete the datapreview should be added to your ckan.plugins property in the appropriate .ini file.
 
+## Config
+
+In your CKAN config file, configure the following options:
+
+### limit
+
+The 'limit' is the maximum size of a file downloaded or loaded into memory. If the data is not stored locally, then you don't want to wait forever downloading it to be able to proxy it. And if the whole file needs to be loaded into memory to display the first 100 rows then you want to limit the file size. e.g. a 20MB XLS file may take up 100MB when parsed in memory, and you don't want to fill your server by loading anything much bigger. 
+
+The limit is expressed in bytes, so the default of 5MB would be:
+
+    ckan.datapreview.limit = 5242880
+
+Local CSV files are not subject to this limit because the first 100 rows can be loaded without loading the whole file into memory.
 
 ## Requirements
 

--- a/ckanext/datapreview/controller.py
+++ b/ckanext/datapreview/controller.py
@@ -36,7 +36,7 @@ class DataPreviewController(BaseController):
         except NotAuthorized, e:
             abort(403, "You are not permitted access to this resource")
 
-        size_limit = config.get('ckan.datapreview.limit', 5000000)
+        size_limit = config.get('ckan.datapreview.limit', 5242880)
 
         qa = QA.get_for_resource(resource.id)
         format_ = qa.format if qa else None

--- a/ckanext/datapreview/lib/helpers.py
+++ b/ckanext/datapreview/lib/helpers.py
@@ -203,7 +203,7 @@ def proxy_query(resource, url, query):
 
     max_length = int(query['size_limit'])
 
-    if query.get('archived', True):
+    if query.get('archived', True) and not trans.local_size_limit():
         log.debug("Skipping size check when reading from archive")
     else:
         # We only do the length check when we are working with remote files as

--- a/ckanext/datapreview/lib/helpers.py
+++ b/ckanext/datapreview/lib/helpers.py
@@ -18,11 +18,12 @@ def get_resource_length(url, resource, required=False, redirects=0):
     '''Get file size of a resource.
 
     Either do a HEAD request to the url, or checking the
-    size on disk.
+    size on disk. (Will not download the whole file.)
 
     :param url: URL to check
     :param resource: Resource object, just for identification purposes
-    :param required: ?
+    :param required: If cannot get the length (without resorting to downloading
+                     the whole file), raises ResourceError
     :param redirects: For counting the number of recursions due to redirects
 
     On error, this method raises ResourceError.
@@ -144,14 +145,24 @@ def proxy_query(resource, url, query):
 
     e.g. if it is a spreadsheet, it returns a JSON dict:
         {
+            "archived": "This file is previewed from the data.gov.uk archive.",
             "fields": ['Name', 'Age'],
             "data": [['Bob', 42], ['Jill', 54]],
+            "extra_text": "This preview shows only the first 10 rows",
             "max_results": 10,
             "length": 435,
             "url": "http://data.com/file.csv",
         }
     Whatever it is, it always has length (file size in bytes) and url (where
     it got the data from, which might be a URL or a local cache filepath).
+
+    Or an error message:
+        {
+            "error": {
+                "message": "Requested resource is 21.3MB. Size limit is  19MB. Resource: /dataset/your-freedom-data/resource/ea11ed1e-d793-4fc6-b150-fb362a7ccac9",
+                "title": "The requested file is too large to preview"
+            }
+        }
 
     May raise RequestError.
 
@@ -197,18 +208,24 @@ def proxy_query(resource, url, query):
 
     length = query.get('length',
                        get_resource_length(url, resource,
-                                           trans.requires_size_limit))
+                                           trans.requires_size_limit()))
 
     log.debug('The file at %s has length %s', url, length)
 
     max_length = int(query['size_limit'])
 
-    if query.get('archived', True) and not trans.local_size_limit():
-        log.debug("Skipping size check when reading from archive")
+    transformer_requires_size_limit = trans.requires_size_limit()
+    log.debug('Size=%s Archived=%s Transformer-limited=%s Limit=%s',
+              int(length), query.get('archived'),
+              transformer_requires_size_limit, max_length)
+    if query.get('archived', True) and not transformer_requires_size_limit:
+        log.debug('Skipping size check - reading from archive and the '
+                  'transformer for this format does not require a limit')
     else:
-        # We only do the length check when we are working with remote files as
-        # they might take too long to download.
-        if length and trans.requires_size_limit and int(length) > max_length:
+        # Do size check
+        #  - remote files may take too long to download
+        #  - some file formats need loading fully into memory and take too much
+        if length and int(length) > max_length:
             raise ResourceError('The requested file is too large to preview',
                                 'Requested resource is %s. '
                                 'Size limit is %s. Resource: %s'

--- a/ckanext/datapreview/transform/base.py
+++ b/ckanext/datapreview/transform/base.py
@@ -40,7 +40,6 @@ class Transformer(object):
         self.url = url
         self.query = query
         self.open_data = query['handler']
-        self.requires_size_limit = True
         self.max_results = 500
         self.mimetype = query.get('mimetype', None)
 
@@ -80,5 +79,8 @@ class Transformer(object):
 
         return result
 
-    def local_size_limit(self):
-        return False
+    def requires_size_limit(self):
+        '''Whether the transformer is subject to the 'limit', due to needing to
+        loading the whole file into memory to only read a sample of it.
+        '''
+        return True

--- a/ckanext/datapreview/transform/base.py
+++ b/ckanext/datapreview/transform/base.py
@@ -79,3 +79,6 @@ class Transformer(object):
             result["max_results"] = self.max_results
 
         return result
+
+    def local_size_limit(self):
+        return False

--- a/ckanext/datapreview/transform/plain_transform.py
+++ b/ckanext/datapreview/transform/plain_transform.py
@@ -16,7 +16,6 @@ class PlainTransformer(Transformer):
 
     def __init__(self, resource, url, query):
         super(PlainTransformer, self).__init__(resource, url, query)
-        self.requires_size_limit = True
 
     def transform(self):
         handle = self.open_data(self.url)

--- a/ckanext/datapreview/transform/tabular_transform.py
+++ b/ckanext/datapreview/transform/tabular_transform.py
@@ -8,7 +8,7 @@ log = __import__('logging').getLogger(__name__)
 
 class TabularTransformer(base.Transformer):
 
-    def __init__(self, resource, url, query, mimetype=None):
+    def __init__(self, resource, url, query):
         super(TabularTransformer, self).__init__(resource, url, query)
         self.requires_size_limit = True
 
@@ -45,11 +45,9 @@ class TabularTransformer(base.Transformer):
 
         # Find a workable sheet with more than 0 rows
         rows = []
-        row_count = 0
         for table in tables:
             # + 1 so that the header is included
-            row_count = len(list(table))
-            rows = _list(table, self.max_results + 1)
+            rows, more_results = _list(table, self.max_results + 1)
             if len(rows) > 0:
                 break
 
@@ -68,11 +66,11 @@ class TabularTransformer(base.Transformer):
 
         if len(tables) > 1:
             extra = "Only 1 of {0} tables shown".format(len(tables))
-            if row_count > self.max_results:
-                extra = extra + " and {0} rows from {1} in this table".format(self.max_results, row_count)
+            if more_results:
+                extra = extra + " and the first {0} rows in this table".format(self.max_results)
         else:
-            if row_count > self.max_results:
-                extra = "This preview shows only {0} rows from {1}".format(self.max_results, row_count)
+            if more_results:
+                extra = "This preview shows only the first {0} rows".format(self.max_results)
 
         result = {
             "fields": fields,
@@ -89,10 +87,12 @@ class TabularTransformer(base.Transformer):
 def _list(iterable, max_results):
     '''Returns the list(iterable) up to a maximum number of results'''
     out = []
+    more_results = False
     count = 0
     for item in iterable:
+        if count > max_results:
+            more_results = True
+            break
         out.append(item)
         count += 1
-        if count == max_results:
-            break
-    return out
+    return out, more_results

--- a/ckanext/datapreview/transform/tabular_transform.py
+++ b/ckanext/datapreview/transform/tabular_transform.py
@@ -10,7 +10,6 @@ class TabularTransformer(base.Transformer):
 
     def __init__(self, resource, url, query):
         super(TabularTransformer, self).__init__(resource, url, query)
-        self.requires_size_limit = True
 
         if 'worksheet' in self.query:
             self.sheet_number = int(self.query.getfirst('worksheet'))
@@ -70,7 +69,7 @@ class TabularTransformer(base.Transformer):
                 extra = extra + " and the first {0} rows in this table".format(self.max_results)
         else:
             if more_results:
-                extra = "This preview shows only the first {0} rows".format(self.max_results)
+                extra = "This preview shows only the first {0} rows - download it for the full file".format(self.max_results)
 
         result = {
             "fields": fields,
@@ -84,17 +83,24 @@ class TabularTransformer(base.Transformer):
 
         return result
 
-    def local_size_limit(self):
+    def requires_size_limit(self):
         if self.is_csv():
+            # We are confident that messytables.CSVTableSet will give us a
+            # sample of the data without having to load the whole of the file
+            # into memory, so we lift the size limit
             return False
         else:
             return True
 
     def is_csv(self):
+        '''This should catch most files for which messytables.any_tableset will
+        use CSVTableSet to parse them.
+        '''
         if self.type.lower() in ['csv', 'tsv']:
             return True
 
-        if self.mimetype.lower() in ["text/csv", "text/comma-separated-values"]:
+        if self.mimetype and self.mimetype.lower() in \
+                ['text/csv', 'text/comma-separated-values', 'application/csv']:
             return True
 
         return False

--- a/ckanext/datapreview/transform/tabular_transform.py
+++ b/ckanext/datapreview/transform/tabular_transform.py
@@ -84,6 +84,21 @@ class TabularTransformer(base.Transformer):
 
         return result
 
+    def local_size_limit(self):
+        if self.is_csv():
+            return False
+        else:
+            return True
+
+    def is_csv(self):
+        if self.type in ['csv', 'tsv']:
+            return True
+
+        if self.mimetype in ["text/csv", "text/comma-separated-values"]:
+            return True
+
+        return False
+
 def _list(iterable, max_results):
     '''Returns the list(iterable) up to a maximum number of results'''
     out = []

--- a/ckanext/datapreview/transform/tabular_transform.py
+++ b/ckanext/datapreview/transform/tabular_transform.py
@@ -91,10 +91,10 @@ class TabularTransformer(base.Transformer):
             return True
 
     def is_csv(self):
-        if self.type in ['csv', 'tsv']:
+        if self.type.lower() in ['csv', 'tsv']:
             return True
 
-        if self.mimetype in ["text/csv", "text/comma-separated-values"]:
+        if self.mimetype.lower() in ["text/csv", "text/comma-separated-values"]:
             return True
 
         return False


### PR DESCRIPTION
Now no longer reads the whole file to get the number of lines to be able to alert that the preview is truncated. 

XLS files are still loaded into memory so the limit on remote file size is extended to them even if they are local.

Need to think if we need different limits for local and remote files?