### PR TITLE
[WIP] Add the plain text transformer back in.

### DIFF
--- a/ckanext/datapreview/transform/__init__.py
+++ b/ckanext/datapreview/transform/__init__.py
@@ -1,10 +1,18 @@
 import sys
 from ckanext.datapreview.transform.base import *
 from ckanext.datapreview.transform.tabular_transform import TabularTransformer
+from ckanext.datapreview.transform.plain_transform import PlainTransformer
 
 register_transformer({
         "name": "csv",
         "class": TabularTransformer,
         "extensions": ["csv", "tsv", "xls", "ods"],
         "mime_types": ["text/csv", "text/comma-separated-values", "application/excel", "application/vnd.ms-excel"]
+    })
+
+register_transformer({
+        "name": "txt",
+        "class": PlainTransformer,
+        "extensions": ["txt", "plain"],
+        "mime_types": ("text/plain",),
     })

--- a/ckanext/datapreview/transform/plain_transform.py
+++ b/ckanext/datapreview/transform/plain_transform.py
@@ -1,13 +1,9 @@
 """Data Proxy - Plain transformation adapter"""
-import urllib2
 from ckanext.datapreview.transform.base import Transformer
 from ckanext.datapreview.lib.errors import ResourceError
-try:
-    import json
-except ImportError:
-    import simplejson as json
 
 MAX_TEXT_SIZE = 8192
+
 
 class PlainTransformer(Transformer):
     """
@@ -18,25 +14,30 @@ class PlainTransformer(Transformer):
 
     def __init__(self, resource, url, query):
         self.size = int(query.get('length', 0))
+        self.from_archive = query.get('archived', False)
         super(PlainTransformer, self).__init__(resource, url, query)
 
     def transform(self):
         handle = self.open_data(self.url)
         if not handle:
             raise ResourceError("Remote resource missing",
-                "Unable to load the remote resource")
+                                "Unable to load the remote resource")
 
         data = handle.read(MAX_TEXT_SIZE)
+        extra_text = ''
         if self.size and (self.size > MAX_TEXT_SIZE):
-            data += "... [output truncated]"
+            data += "\n... [output truncated]"
+            extra_text = 'Only the first %sk shown - download it for the full'\
+                         ' file.' % int(MAX_TEXT_SIZE/1024.0)
 
         data = data.decode('utf-8', 'ignore')
         result = {
                     "fields": ["data"],
-                    "data": [["%s" % (data)]]
+                    "data": [["%s" % (data)]],
+                    "extra_text": extra_text,
+                    "archived": "This file is previewed from the data.gov.uk archive." if self.from_archive else ""
                   }
 
         self.close_stream(handle)
 
         return result
-

--- a/ckanext/datapreview/transform/plain_transform.py
+++ b/ckanext/datapreview/transform/plain_transform.py
@@ -7,6 +7,8 @@ try:
 except ImportError:
     import simplejson as json
 
+MAX_TEXT_SIZE = 8192
+
 class PlainTransformer(Transformer):
     """
     A plain transformer that just packages the data up (assuming it is within
@@ -15,6 +17,7 @@ class PlainTransformer(Transformer):
     """
 
     def __init__(self, resource, url, query):
+        self.size = int(query.get('length', 0))
         super(PlainTransformer, self).__init__(resource, url, query)
 
     def transform(self):
@@ -23,7 +26,11 @@ class PlainTransformer(Transformer):
             raise ResourceError("Remote resource missing",
                 "Unable to load the remote resource")
 
-        data = handle.read().decode('utf-8', 'ignore')
+        data = handle.read(MAX_TEXT_SIZE)
+        if self.size and (self.size > MAX_TEXT_SIZE):
+            data += "... [output truncated]"
+
+        data = data.decode('utf-8', 'ignore')
         result = {
                     "fields": ["data"],
                     "data": [["%s" % (data)]]


### PR DESCRIPTION
In issue 340 I think the plain text transformer was accidentally removed. It was right to stop rendering XML etc, but the JavaScript still tries to load the plain text preview, but there is no longer a transformer.

Out resource page currently says plain text preview is supported - "Preview is currently available for files such as CSV, spreadsheets and plain text. ".

One issue is that we have 34 cached files greater than 1Mb with the largest being 214Mb. What is a sensible way to truncate plain text?
