### PR TITLE
[WIP] Check the remote mimetype before rendering

### DIFF
--- a/ckanext/datapreview/transform/__init__.py
+++ b/ckanext/datapreview/transform/__init__.py
@@ -2,9 +2,11 @@ import sys
 from ckanext.datapreview.transform.base import *
 from ckanext.datapreview.transform.tabular_transform import TabularTransformer
 
+ALLOWED_MIMETYPES = ["text/csv", "text/comma-separated-values", "application/excel", "application/vnd.ms-excel"]
+
 register_transformer({
         "name": "csv",
         "class": TabularTransformer,
         "extensions": ["csv", "tsv", "xls", "ods"],
-        "mime_types": ["text/csv", "text/comma-separated-values", "application/excel", "application/vnd.ms-excel"]
+        "mime_types": ALLOWED_MIMETYPES
     })


### PR DESCRIPTION
Datapreview accepts the format sent in the query params is correct, and
often it isn't.  If when requesting the data the preview is returning a
non-displayable mimetype, then it now errors.

e.g. client sends format=csv, if fetching the data determines it is actually 
text/plain then it is not rendered.

This should resolve issues where someone points to a CSV that now 
resolves to HTML (because there's no decent 404 handler for instance).
